### PR TITLE
(fix): Updated version in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "do0dle-colors",
-  "version": "2.0.0",
+  "version": "2.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "do0dle-colors",
-      "version": "2.0.0",
+      "version": "2.1.3",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^29.5.1",


### PR DESCRIPTION
Just a quick update to match the package-lock.json with the package.json version